### PR TITLE
Isolate include to avoid variable conflicts

### DIFF
--- a/Command/LoadSetsCommand.php
+++ b/Command/LoadSetsCommand.php
@@ -56,7 +56,7 @@ class LoadSetsCommand extends ContainerAwareCommand
             $output->write("Loading file '$file' ... ");
 
             // The file should return a FixtureSetInterface
-            $set = include($file);
+            $set = $this->loadSet($file);
 
             if (!$set || !($set instanceof FixtureSetInterface)) {
                 throw new \InvalidArgumentException("File '$file' does not return a FixtureSetInterface.");
@@ -66,5 +66,10 @@ class LoadSetsCommand extends ContainerAwareCommand
 
             $output->writeln("loaded " . count($entities) . " entities ... done.");
         }
+    }
+    
+    protected function loadSet($file)
+    {
+        return include $file;
     }
 }


### PR DESCRIPTION
With the existing code if you declare things like $output in a set you can mess up the parent code execution. Isolating it is safer.
