### PR TITLE
Fixing CompilerPasses bug becauses of missing aliased definition.

### DIFF
--- a/DependencyInjection/Compiler/ProcessorCompilerPass.php
+++ b/DependencyInjection/Compiler/ProcessorCompilerPass.php
@@ -24,11 +24,7 @@ class ProcessorCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (false === $container->hasDefinition('h4cc_alice_fixtures.manager')) {
-            return;
-        }
-
-        $definition = $container->getDefinition('h4cc_alice_fixtures.manager');
+        $definition = $container->findDefinition('h4cc_alice_fixtures.manager');
 
         foreach (array_keys($container->findTaggedServiceIds('h4cc_alice_fixtures.processor')) as $id) {
             $definition->addMethodCall('addProcessor', array(new Reference($id)));

--- a/DependencyInjection/Compiler/ProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/ProviderCompilerPass.php
@@ -24,11 +24,7 @@ class ProviderCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (false === $container->hasDefinition('h4cc_alice_fixtures.manager')) {
-            return;
-        }
-
-        $definition = $container->getDefinition('h4cc_alice_fixtures.manager');
+        $definition = $container->findDefinition('h4cc_alice_fixtures.manager');
 
         foreach (array_keys($container->findTaggedServiceIds('h4cc_alice_fixtures.provider')) as $id) {
             $definition->addMethodCall('addProvider', array(new Reference($id)));

--- a/Tests/DependencyInjection/Compiler/ProcessorCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ProcessorCompilerPassTest.php
@@ -31,21 +31,18 @@ class ProcessorCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->compilerPass = new ProcessorCompilerPass();
 
         $this->containerMock = $this->getMockBuilder('\Symfony\Component\DependencyInjection\ContainerBuilder')
-          ->setMethods(array('hasDefinition', 'getDefinition', 'findTaggedServiceIds'))
+          ->setMethods(array('findDefinition', 'findTaggedServiceIds'))
           ->disableOriginalConstructor()
           ->getMock();
     }
 
     public function testProcess()
     {
-        $this->containerMock->expects($this->once())->method('hasDefinition')
-          ->with('h4cc_alice_fixtures.manager')->will($this->returnValue(true));
-
         $definitionMock = $this->getMockBuilder('\Symfony\Component\DependencyInjection\Definition')
           ->setMethods(array('addMethodCall'))
           ->disableOriginalConstructor()
           ->getMock();
-        $this->containerMock->expects($this->once())->method('getDefinition')
+        $this->containerMock->expects($this->once())->method('findDefinition')
           ->with('h4cc_alice_fixtures.manager')->will($this->returnValue($definitionMock));
 
         $taggedServices = array(
@@ -58,14 +55,6 @@ class ProcessorCompilerPassTest extends \PHPUnit_Framework_TestCase
 
         $definitionMock->expects($this->exactly(2))->method('addMethodCall');
 
-        $this->compilerPass->process($this->containerMock);
-    }
-
-    public function testProcessNoManager()
-    {
-        $this->containerMock->expects($this->once())->method('hasDefinition')->with(
-            'h4cc_alice_fixtures.manager'
-        )->will($this->returnValue(false));
         $this->compilerPass->process($this->containerMock);
     }
 }

--- a/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
@@ -31,21 +31,18 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->compilerPass = new ProviderCompilerPass();
 
         $this->containerMock = $this->getMockBuilder('\Symfony\Component\DependencyInjection\ContainerBuilder')
-          ->setMethods(array('hasDefinition', 'getDefinition', 'findTaggedServiceIds'))
+          ->setMethods(array('findDefinition', 'findTaggedServiceIds'))
           ->disableOriginalConstructor()
           ->getMock();
     }
 
     public function testProcess()
     {
-        $this->containerMock->expects($this->once())->method('hasDefinition')
-          ->with('h4cc_alice_fixtures.manager')->will($this->returnValue(true));
-
         $definitionMock = $this->getMockBuilder('\Symfony\Component\DependencyInjection\Definition')
           ->setMethods(array('addMethodCall'))
           ->disableOriginalConstructor()
           ->getMock();
-        $this->containerMock->expects($this->once())->method('getDefinition')
+        $this->containerMock->expects($this->once())->method('findDefinition')
           ->with('h4cc_alice_fixtures.manager')->will($this->returnValue($definitionMock));
 
         $taggedServices = array(
@@ -58,14 +55,6 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
 
         $definitionMock->expects($this->exactly(2))->method('addMethodCall');
 
-        $this->compilerPass->process($this->containerMock);
-    }
-
-    public function testProcessNoManager()
-    {
-        $this->containerMock->expects($this->once())->method('hasDefinition')->with(
-            'h4cc_alice_fixtures.manager'
-        )->will($this->returnValue(false));
         $this->compilerPass->process($this->containerMock);
     }
 }


### PR DESCRIPTION
Closing https://github.com/h4cc/AliceFixturesBundle/issues/18
