### PR TITLE
Avoid replacing the native alice providers

### DIFF
--- a/Fixtures/FixtureManager.php
+++ b/Fixtures/FixtureManager.php
@@ -285,7 +285,11 @@ class FixtureManager implements FixtureManagerInterface
                 $loader->setLogger($this->logger);
             }
         }
-        $loader->setProviders($this->providers);
+        if (is_callable($loader, 'addProvider')) { // new in Alice 1.7.2
+            $loader->addProvider($this->providers);
+        } else { // BC path
+            $loader->setProviders($this->providers);
+        }
     }
 
     /**


### PR DESCRIPTION
This caused nelmio/alice#151 and nelmio/alice#148 - the identity provider added in Base.php's constructor is removed by the setProviders call. 1.7.2 fixes it, but I wrote the patch in a BC way so it's still usable with older alice versions.
