### PR TITLE
Added debug message before loading files

### DIFF
--- a/Fixtures/FixtureManager.php
+++ b/Fixtures/FixtureManager.php
@@ -146,6 +146,7 @@ class FixtureManager implements FixtureManagerInterface
             $loader = $loaders[$file['type']];
 
             $loader->setReferences($references);
+            $this->logDebug(sprintf('Loading file: %s ...', $file['path']));
             $newObjects = $loader->load($file['path']);
             $references = $loader->getReferences();
 


### PR DESCRIPTION
When loader is not able to parse a file, only the error message is shown, but not the file in which it occurs (when loading sets).
I added debug message before loading files which can be accessed when debugging with command app/console h4cc_alice_fixtures:load:sets -vvv
