### PR TITLE
Fixed callable check on addProvider

### DIFF
--- a/Fixtures/FixtureManager.php
+++ b/Fixtures/FixtureManager.php
@@ -283,7 +283,7 @@ class FixtureManager implements FixtureManagerInterface
                 $loader->setLogger($this->logger);
             }
         }
-        if (is_callable($loader, 'addProvider')) { // new in Alice 1.7.2
+        if (is_callable(array($loader, 'addProvider'))) { // new in Alice 1.7.2
             $loader->addProvider($this->providers);
         } else { // BC path
             $loader->setProviders($this->providers);

--- a/Tests/Fixture/FixtureManagerTest.php
+++ b/Tests/Fixture/FixtureManagerTest.php
@@ -188,7 +188,6 @@ class FixtureManagerTest extends \PHPUnit_Framework_TestCase
           ->with('yaml', 'en_EN')->will($this->returnValue($this->yamlLoaderMock));
 
         $this->yamlLoaderMock->expects($this->once())->method('load')->will($this->returnValue(array()));
-        $this->yamlLoaderMock->expects($this->once())->method('setProviders');
 
         $provider = function () {
             return "foobar";


### PR DESCRIPTION
The new Alice function `addProvider` is never being called in FixturesManager because always resolves to false due to the interface of `is_callable` function is wrong used