### PR TITLE
Do not crash when there is no ObjectManager for persisting object

### DIFF
--- a/ORM/Doctrine.php
+++ b/ORM/Doctrine.php
@@ -43,10 +43,17 @@ class Doctrine implements ORMInterface
     public function persist(array $objects)
     {
         foreach ($objects as $object) {
-            $manager = $this->getManagerFor($object);
-            $this->managersToFlush->attach($manager);
+            $manager = null;
 
-            $manager->persist($object);
+            try {
+                $manager = $this->getManagerFor($object);
+            } catch (\RuntimeException $e) {}
+
+            if (null !== $manager) {
+                $this->managersToFlush->attach($manager);
+
+                $manager->persist($object);
+            }
         }
 
         $this->flush();
@@ -137,4 +144,3 @@ class Doctrine implements ORMInterface
         $this->managersToFlush->removeAll($this->managersToFlush);
     }
 }
- 


### PR DESCRIPTION
Not crashing allows creating objects that are not doctrine entities (e.g. doctrine embedded objects).

````
Path\To\EmbeddedClass:
    text_{1..50}:
        source: <realText()>
        html: <realText()>

Path\To\MappedEntity:
    mapped_{1..50}:
        description: @text_*
        about: @text_*