### PR TITLE
Use nelmio/alice's newer version

### DIFF
--- a/Fixtures/FixtureManager.php
+++ b/Fixtures/FixtureManager.php
@@ -13,8 +13,7 @@ namespace h4cc\AliceFixturesBundle\Fixtures;
 
 use h4cc\AliceFixturesBundle\ORM\ORMInterface;
 use Nelmio\Alice\Fixtures;
-use Nelmio\Alice\Loader\Base;
-use Nelmio\Alice\LoaderInterface;
+use Nelmio\Alice\Fixtures\Loader;
 use Nelmio\Alice\ProcessorInterface;
 use Psr\Log\LoggerInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
@@ -53,7 +52,7 @@ class FixtureManager implements FixtureManagerInterface
      */
     protected $options = array();
     /**
-     * @var \Nelmio\Alice\ORM\Doctrine
+     * @var \Nelmio\Alice\Persister\Doctrine
      */
     protected $orm;
     /**
@@ -164,7 +163,7 @@ class FixtureManager implements FixtureManagerInterface
 
     /**
      * @param FixtureSet $set
-     * @return \Nelmio\Alice\LoaderInterface[]
+     * @return \Nelmio\Alice\Fixtures\Loader[]
      */
     private function createNeededLoaders(FixtureSet $set)
     {
@@ -173,7 +172,7 @@ class FixtureManager implements FixtureManagerInterface
         foreach ($set->getFiles() as $file) {
             $type = $file['type'];
             if (!isset($loaders[$type])) {
-                $loader = $this->loaderFactory->getLoader($type, $set->getLocale());
+                $loader = $this->loaderFactory->getLoader($set->getLocale());
                 $this->configureLoader($loader);
                 $loaders[$type] = $loader;
                 $this->logDebug("Created loader for type '$type'.");
@@ -273,12 +272,12 @@ class FixtureManager implements FixtureManagerInterface
     /**
      * Sets all needed options and dependencies to a loader.
      *
-     * @param LoaderInterface $loader
+     * @param Loader $loader
      */
-    protected function configureLoader(LoaderInterface $loader)
+    protected function configureLoader(Loader $loader)
     {
-        if ($loader instanceof Base) {
-            $loader->setORM($this->getORM());
+        if ($loader instanceof Loader) {
+            $loader->setPersister($this->getORM());
             if ($this->logger) {
                 $loader->setLogger($this->logger);
             }

--- a/Fixtures/FixtureManagerInterface.php
+++ b/Fixtures/FixtureManagerInterface.php
@@ -23,10 +23,9 @@ interface FixtureManagerInterface
      * Does _not_ persist them, use persist() for that.
      *
      * @param array $files
-     * @param string $type
      * @return array
      */
-    public function loadFiles(array $files, $type = 'yaml');
+    public function loadFiles(array $files);
 
     /**
      * Creates a new configured fixture set.

--- a/Loader/Factory.php
+++ b/Loader/Factory.php
@@ -11,8 +11,7 @@
 
 namespace h4cc\AliceFixturesBundle\Loader;
 
-use Nelmio\Alice\Loader\Base as BaseLoader;
-use Nelmio\Alice\Loader\Yaml as YamlLoader;
+use Nelmio\Alice\Fixtures\Loader;
 
 /**
  * Class Factory
@@ -25,29 +24,11 @@ class Factory implements FactoryInterface
     /**
      * Returns a loader for a specific type and locale.
      *
-     * @param $type
      * @param $locale
-     * @return BaseLoader|YamlLoader
-     * @throws \InvalidArgumentException
+     * @return Loader
      */
-    public function getLoader($type, $locale)
+    public function getLoader($locale)
     {
-        switch ($type) {
-            case 'yaml':
-                return $this->newLoaderYaml($locale);
-            case 'php':
-                return $this->newLoaderPHP($locale);
-        }
-        throw new \InvalidArgumentException("Unknown loader type '$type'.");
-    }
-
-    protected function newLoaderYaml($locale)
-    {
-        return new YamlLoader($locale);
-    }
-
-    protected function newLoaderPHP($locale)
-    {
-        return new BaseLoader($locale);
+        return new Loader($locale);
     }
 }

--- a/Loader/FactoryInterface.php
+++ b/Loader/FactoryInterface.php
@@ -11,7 +11,7 @@
 
 namespace h4cc\AliceFixturesBundle\Loader;
 
-use Nelmio\Alice\LoaderInterface;
+use Nelmio\Alice\Fixtures\Loader;
 
 /**
  * Interface FactoryInterface
@@ -23,9 +23,8 @@ interface FactoryInterface
     /**
      * Returns a loader for a specific type and locale.
      *
-     * @param $type
      * @param $locale
-     * @return LoaderInterface
+     * @return Loader
      */
-    public function getLoader($type, $locale);
+    public function getLoader($locale);
 }

--- a/ORM/ORMInterface.php
+++ b/ORM/ORMInterface.php
@@ -11,7 +11,7 @@
 
 namespace h4cc\AliceFixturesBundle\ORM;
 
-use Nelmio\Alice\ORMInterface as NelmioORMInterface;
+use Nelmio\Alice\PersisterInterface as NelmioORMInterface;
 
 /**
  * Interface for Object Relation Mapping operations.

--- a/Tests/Fixture/FixtureManagerTest.php
+++ b/Tests/Fixture/FixtureManagerTest.php
@@ -12,7 +12,8 @@
 namespace h4cc\AliceFixturesBundle\Tests\Fixtures;
 
 use h4cc\AliceFixturesBundle\Fixtures\FixtureManager;
-use Nelmio\Alice\Loader\Yaml;
+
+use Nelmio\Alice\Fixtures\Loader;
 
 /**
  * Class FixtureManagerTest
@@ -54,9 +55,8 @@ class FixtureManagerTest extends \PHPUnit_Framework_TestCase
           ->disableOriginalConstructor()
           ->getMock();
 
-        $this->yamlLoaderMock = $this->getMockBuilder('\Nelmio\Alice\Loader\Yaml')
+        $this->yamlLoaderMock = $this->getMockBuilder('\Nelmio\Alice\Fixtures\Loader')
           ->setMethods(array('setProviders', 'addProvider', 'load'))
-          ->disableOriginalConstructor()
           ->getMock();
 
         $this->factoryMock = $this->getMockBuilder('\h4cc\AliceFixturesBundle\Loader\FactoryInterface')
@@ -132,7 +132,7 @@ class FixtureManagerTest extends \PHPUnit_Framework_TestCase
     public function testLoadYaml()
     {
         $this->factoryMock->expects($this->any())->method('getLoader')
-          ->with('yaml', 'en_EN')->will($this->returnValue(new Yaml()));
+          ->with('en_EN')->will($this->returnValue(new Loader()));
 
         $this->managerRegistryMock->expects($this->any())->method('getManagerForClass')
           ->will($this->returnValue($this->objectManagerMock));
@@ -146,7 +146,7 @@ class FixtureManagerTest extends \PHPUnit_Framework_TestCase
     public function testProcessor()
     {
         $this->factoryMock->expects($this->any())->method('getLoader')
-          ->with('yaml', 'en_EN')->will($this->returnValue(new Yaml()));
+          ->with('en_EN')->will($this->returnValue(new Loader()));
 
         $this->managerRegistryMock->expects($this->any())->method('getManagerForClass')
           ->will($this->returnValue($this->objectManagerMock));
@@ -185,7 +185,7 @@ class FixtureManagerTest extends \PHPUnit_Framework_TestCase
     public function testProviders()
     {
         $this->factoryMock->expects($this->any())->method('getLoader')
-          ->with('yaml', 'en_EN')->will($this->returnValue($this->yamlLoaderMock));
+          ->with('en_EN')->will($this->returnValue($this->yamlLoaderMock));
 
         $this->yamlLoaderMock->expects($this->once())->method('load')->will($this->returnValue(array()));
 
@@ -207,7 +207,7 @@ class FixtureManagerTest extends \PHPUnit_Framework_TestCase
     {
         // We need a real YAML Loader for this.
         $this->factoryMock->expects($this->any())->method('getLoader')
-          ->with('yaml', 'en_EN')->will($this->returnValue(new Yaml()));
+          ->with('en_EN')->will($this->returnValue(new Loader()));
 
         $this->managerRegistryMock->expects($this->any())->method('getManagerForClass')
           ->will($this->returnValue($this->objectManagerMock));

--- a/Tests/Loader/FactoryTest.php
+++ b/Tests/Loader/FactoryTest.php
@@ -33,21 +33,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testGetLoader()
     {
-        $loader = $this->factory->getLoader('yaml', 'de_DE');
+        $loader = $this->factory->getLoader('de_DE');
 
-        $this->assertInstanceOf('\Nelmio\Alice\Loader\Yaml', $loader);
-
-        $loader = $this->factory->getLoader('php', 'de_DE');
-
-        $this->assertInstanceOf('\Nelmio\Alice\Loader\Base', $loader);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unknown loader type 'foo'.
-     */
-    public function testException()
-    {
-        $this->factory->getLoader('foo', 'bar');
+        $this->assertInstanceOf('\Nelmio\Alice\Fixtures\Loader', $loader);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "nelmio/alice": "~1.6",
+        "nelmio/alice": "~2.0",
         "doctrine/common": "~2.1",
         "psr/log": "~1.0",
         "symfony/finder": "~2.0"


### PR DESCRIPTION
If it isn't breaking anything, AliceFixturesBundle could require Alice's new [2.0](https://github.com/nelmio/alice/releases/tag/2.0.0) version instead of 1.6.
